### PR TITLE
Add utils for propagating the transaction via Context

### DIFF
--- a/dbutils/dbutils.go
+++ b/dbutils/dbutils.go
@@ -183,7 +183,7 @@ type BeginnerExecutor interface {
 
 // Transaction wraps a function within an SQL transaction, that can be used to run multiple statements in a safe way
 // In case of errors or panics, the transaction will be rolled back
-func Transaction(db BeginnerExecutor, ctx context.Context, txFunc func(tx *sql.Tx) error) (err error) {
+func Transaction(db BeginnerExecutor, txFunc func(tx *sql.Tx) error) (err error) {
 	return TransactionCtx(context.TODO(), db, func(ctx context.Context) error {
 		return txFunc(Tx(ctx))
 	})

--- a/dbutils/dbutils.go
+++ b/dbutils/dbutils.go
@@ -6,10 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"runtime/debug"
 	"strings"
 	"time"
 
 	"github.com/pressly/goose/v3"
+	"github.com/prometheus/common/log"
 	"github.com/top-solution/go-libs/config"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 	"github.com/volatiletech/sqlboiler/v4/queries"
@@ -215,8 +217,9 @@ func TransactionCtx(ctx context.Context, db BeginnerExecutor, txFunc func(ctx co
 			case error:
 				err = fmt.Errorf("transaction failed: %w", x)
 			default:
-				err = fmt.Errorf("unknown panic: %v", x)
+				err = fmt.Errorf("transaction failed for unknown panic: %v", x)
 			}
+			log.Error("transaction failed", "err", err, "stack", string(debug.Stack()))
 		} else if err != nil {
 			rollbackErr := tx.Rollback() // err is non-nil; don't change it
 			if rollbackErr != nil {

--- a/dbutils/dbutils.go
+++ b/dbutils/dbutils.go
@@ -213,7 +213,7 @@ func TransactionCtx(ctx context.Context, db BeginnerExecutor, txFunc func(ctx co
 			case string:
 				err = errors.New(x)
 			case error:
-				err = fmt.Errorf("transaction failed: %w", err)
+				err = fmt.Errorf("transaction failed: %w", x)
 			default:
 				err = fmt.Errorf("unknown panic: %v", x)
 			}

--- a/dbutils/dbutils.go
+++ b/dbutils/dbutils.go
@@ -237,6 +237,7 @@ func TxOr(ctx context.Context, fallback boil.Executor) boil.Executor {
 	return tx
 }
 
+// Tx extracts a transaction from a context, returns nil if no transaxction is found
 func Tx(ctx context.Context) *sql.Tx {
 	tx, ok := ctx.Value(TxKey).(*sql.Tx)
 	if !ok {

--- a/dbutils/dbutils.go
+++ b/dbutils/dbutils.go
@@ -211,7 +211,9 @@ func TransactionCtx(ctx context.Context, db BeginnerExecutor, txFunc func(ctx co
 			err = fmt.Errorf("transaction failed: %w", err)
 		} else if err != nil {
 			rollbackErr := tx.Rollback() // err is non-nil; don't change it
-			log.Println(rollbackErr)
+			if rollbackErr != nil {
+				log.Printf("%s: %s", p, debug.Stack())
+			}
 		} else {
 			err = tx.Commit() // err is nil; if Commit returns an error, update err
 			if err != nil {

--- a/dbutils/dbutils.go
+++ b/dbutils/dbutils.go
@@ -235,7 +235,10 @@ func TxOr(ctx context.Context, fallback boil.Executor) boil.Executor {
 }
 
 func Tx(ctx context.Context) *sql.Tx {
-	tx := ctx.Value(TxKey).(*sql.Tx)
+	tx, ok := ctx.Value(TxKey).(*sql.Tx)
+	if !ok {
+		return nil
+	}
 	return tx
 }
 

--- a/dbutils/dbutils.go
+++ b/dbutils/dbutils.go
@@ -209,7 +209,14 @@ func TransactionCtx(ctx context.Context, db BeginnerExecutor, txFunc func(ctx co
 			if rollbackErr != nil {
 				panic(p)
 			}
-			err = fmt.Errorf("transaction failed: %w", err)
+			switch x := p.(type) {
+			case string:
+				err = errors.New(x)
+			case error:
+				err = fmt.Errorf("transaction failed: %w", err)
+			default:
+				err = fmt.Errorf("unknown panic: %v", x)
+			}
 		} else if err != nil {
 			rollbackErr := tx.Rollback() // err is non-nil; don't change it
 			if rollbackErr != nil {

--- a/go.mod
+++ b/go.mod
@@ -12,14 +12,18 @@ require (
 	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac
 	github.com/ory/ladon v1.2.0
 	github.com/pressly/goose/v3 v3.4.1
+	github.com/prometheus/common v0.4.0
 	github.com/serjlee/frequency v0.0.0-20220208211258-20a3cde71a58
 	github.com/sirupsen/logrus v1.8.1
+	github.com/stretchr/testify v1.7.0
 	github.com/volatiletech/sqlboiler/v4 v4.6.0
 	goa.design/goa/v3 v3.2.6
 	goa.design/plugins v2.2.6+incompatible
 )
 
 require (
+	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
+	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598 // indirect
 	github.com/dlclark/regexp2 v1.2.0 // indirect
@@ -37,7 +41,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/volatiletech/inflect v0.0.1 // indirect
 	github.com/volatiletech/strmangle v0.0.1 // indirect
 	github.com/zach-klippenstein/goregen v0.0.0-20160303162051-795b5e3961ea // indirect
@@ -46,6 +49,7 @@ require (
 	golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac // indirect
 	golang.org/x/tools v0.0.0-20210106214847-113979e3529a // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -15,7 +15,9 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
+github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/apmckinlay/gsuneido v0.0.0-20180907175622-1f10244968e3/go.mod h1:hJnaqxrCRgMCTWtpNz9XUFkBCREiQdlcyK6YNmOfroM=
@@ -363,6 +365,7 @@ github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
+github.com/prometheus/common v0.4.0 h1:7etb9YClo3a6HjLzfl6rIQaU+FDfi0VSX39io3aQ+DM=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
@@ -604,6 +607,7 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Use case: 

I want to have funcs that can be run in a given transaction or just run a simple query
I want to have funcs that can start their own transaction or re-use an existing one
I don't want to pass an explicit `*sql.Tx` var in every func

New funcs:

`TransactionCtx()` is the same as `Transaction` but it expects a Context in input, with or without a Transaction in it. If no transactions are found, a new one is started
`WithTx` adds a transaction to the context. Used by `TransactionCtx`
 `Tx` returns the transaction in the context (or nil). To be mostly used in the func passed to`TransactionCtx`
 `TxOr` is the same as `Tx` but can fallback to a given DB executor 

Example:

```go

type mystuff struct {
  DB *dbutils.DB
}

func (c mystuff) myfunc(ctx context.Context,) {
	return dbutils.TransactionCtx(ctx, c.DB, func(txctx context.Context) error {
              .... stuff
             err =  runMyQueryWith(dbutils.Tx(txctx)) // run a query in the newly created transaction
              ...
             data, err := c.anotherFuncWithCtx(txctx, args) // pass the ctx with the transaction to another func
              ...
             data, err := c.anotherFuncWithTxCtx(txctx, args) // pass the ctx with the transaction to another func that would normally open a new transaction 
              ...
        }
}
func (c mystuff)  anotherFuncWithCtx(ctx context.Context, args) {
   ...   runMyQueryWith(dbutils.TxOr(ctx, c.DB)) // Run with transaction if found in context or just as one-off query
}

func (c mystuff)  anotherFuncWithTxCtx(ctx context.Context, args) {
 // Run with transaction if found in context or open a new one
  return dbutils.TransactionCtx(ctx, c.DB, func(ctx context.Context) error {
      ...  runMyQueryWith(dbutils.Tx(ctx))
  }
}
...

// Somewhere in an API controller
...
mystuff.myfunc(ctx)
...

```

In the given example, only one transaction is started and used in all funcs
