### PR TITLE
CSV encoder

### DIFF
--- a/middlewares/codec/codec.go
+++ b/middlewares/codec/codec.go
@@ -1,0 +1,33 @@
+package codec
+
+import (
+	"context"
+	"encoding/csv"
+	"io"
+	"net/http"
+
+	goahttp "goa.design/goa/v3/http"
+)
+
+// ResponseEncoder is a custom goa Encoder able to output data in CSV format
+// It can support any endpoint returning a list of fields, a map of fields or struct with a "Data" field containing a  valid list or map (ie: pagination structs)
+// Note it doesn't properly handle nested structs.
+//
+// Clients are supposed to set the Accept header to application/csv in order to get the actual CSV
+func ResponseEncoder(ctx context.Context, w http.ResponseWriter) goahttp.Encoder {
+	var accept string
+	if a := ctx.Value(goahttp.AcceptTypeKey); a != nil {
+		accept = a.(string)
+	}
+	if accept == "application/csv" {
+		goahttp.SetContentType(w, accept)
+		return newCSVEncoder(w)
+	}
+	return goahttp.ResponseEncoder(ctx, w)
+}
+
+func newCSVEncoder(w io.Writer) goahttp.Encoder {
+	wr := csv.NewWriter(w)
+	wr.Comma = ';'
+	return &CSVEncoder{wr}
+}

--- a/middlewares/codec/codec.go
+++ b/middlewares/codec/codec.go
@@ -10,17 +10,29 @@ import (
 )
 
 // ResponseEncoder is a custom goa Encoder able to output data in CSV format
-// It can support any endpoint returning a list of fields, a map of fields or struct with a "Data" field containing a  valid list or map (ie: pagination structs)
-// Note it doesn't properly handle nested structs.
+// It can support any endpoint returning:
+// - A slice of structs
+// - A struct containing a "Data" field which is a slice of structs (ie: Pagination wrappers)
+// - A simple map
+// - A struct containing a "Data" field which is a simple map
+//
+// Note: nested structs are handled only for the first level, and only for slices
 //
 // Clients are supposed to set the Accept header to application/csv in order to get the actual CSV
 func ResponseEncoder(ctx context.Context, w http.ResponseWriter) goahttp.Encoder {
-	var accept string
+	var ct string
+	// Read Accept header from client
 	if a := ctx.Value(goahttp.AcceptTypeKey); a != nil {
-		accept = a.(string)
+		ct = a.(string)
 	}
-	if accept == "application/csv" {
-		goahttp.SetContentType(w, accept)
+
+	// Read ContentType("") DSL from goa design (for enforced CSV endpoints)
+	if a := ctx.Value(goahttp.ContentTypeKey); a != nil {
+		ct = a.(string)
+	}
+
+	if ct == "application/csv" {
+		goahttp.SetContentType(w, ct)
 		return newCSVEncoder(w)
 	}
 	return goahttp.ResponseEncoder(ctx, w)

--- a/middlewares/codec/csv.go
+++ b/middlewares/codec/csv.go
@@ -1,0 +1,89 @@
+package codec
+
+import (
+	"encoding/csv"
+	"fmt"
+	"reflect"
+)
+
+type CSVEncoder struct {
+	enc *csv.Writer
+}
+
+func (e *CSVEncoder) Encode(v interface{}) error {
+	switch reflect.TypeOf(v).Kind() {
+	case reflect.Interface, reflect.Ptr:
+		return e.Encode(reflect.ValueOf(v).Elem().Interface())
+	case reflect.Slice:
+		return e.enc.WriteAll(recordizeSlice(v))
+	case reflect.Map:
+		return e.enc.WriteAll(recordizeMap(v))
+	case reflect.Struct:
+		data := reflect.ValueOf(v).FieldByName("Data")
+		if data != (reflect.Value{}) {
+			return e.Encode(data.Interface())
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+func recordizeMap(input interface{}) [][]string {
+	object := reflect.ValueOf(input)
+	values := object.MapRange()
+	var record []string
+	var header []string
+	for values.Next() {
+		header = append(header, fmt.Sprintf("%v", values.Key().Interface()))
+		record = append(record, fmt.Sprintf("%v", values.Value().Interface()))
+	}
+	return [][]string{header, record}
+}
+
+// Convert an interface{} containing a slice of structs into [][]string.
+func recordizeSlice(input interface{}) [][]string {
+	if strs, isStringsSlice := input.([][]string); isStringsSlice {
+		return strs
+	}
+	var records [][]string
+	var header []string // The first record in records will contain the names of the fields
+	object := reflect.ValueOf(input)
+
+	if object.Len() == 0 {
+		return nil
+	}
+
+	// The first record in the records slice should contain headers / field names
+	first := object.Index(0).Elem()
+
+	typ := first.Type()
+
+	for i := 0; i < first.NumField(); i++ {
+		header = append(header, typ.Field(i).Name)
+	}
+
+	records = append(records, header)
+
+	// Make a slice of objects to iterate through & populate the string slice
+	var items []interface{}
+	for i := 0; i < object.Len(); i++ {
+		items = append(items, object.Index(i).Elem().Interface())
+	}
+
+	// Populate the rest of the items into <records>
+	for _, v := range items {
+		item := reflect.ValueOf(v)
+		var record []string
+		for i := 0; i < item.NumField(); i++ {
+			var itm interface{} = ""
+			val := reflect.Indirect(item.Field(i))
+			if val != (reflect.Value{}) {
+				itm = val.Interface()
+			}
+			record = append(record, fmt.Sprintf("%v", itm))
+		}
+		records = append(records, record)
+	}
+	return records
+}

--- a/middlewares/server.go
+++ b/middlewares/server.go
@@ -13,6 +13,7 @@ import (
 
 	log "github.com/inconshreveable/log15"
 	fslib "github.com/top-solution/go-libs/fs"
+	"github.com/top-solution/go-libs/middlewares/codec"
 	"github.com/top-solution/go-libs/middlewares/meta"
 	goahttp "goa.design/goa/v3/http"
 	goa "goa.design/goa/v3/pkg"
@@ -28,7 +29,7 @@ type Server struct {
 
 func New(entry log.Logger) Server {
 	dec := goahttp.RequestDecoder
-	enc := goahttp.ResponseEncoder
+	enc := codec.ResponseEncoder // use custom encoder handling CSV
 
 	mux := NewMuxer()
 	mux.Handle("GET", "/alive", Alive())


### PR DESCRIPTION
`ResponseEncoder` is a custom goa Encoder able to output data in CSV format, which is now set to be the new **default encoder** in go-libs.

 It supports any endpoint returning:
 - A slice of structs
 - A struct containing a "Data" field which is a slice of structs (ie: Pagination wrappers)
 - A simple map
 - A struct containing a "Data" field which is a simple map

Note: nested structs are handled only for the first level, and only for slices

Clients are supposed to set the `Accept` header to `application/csv` in order to get the actual CSV

-- 
Example API response:

```json
{
	"limit": 200,
	"offset": 0,
	"total": 71705,
	"data": [
		{
			"id": 241265,
			"deviceId": 167,
			"destinationPort": 443,
			"sourcePort": 54683,
			"proto": 6,
			"upload": 777,
			"download": 164,
			"total": 941,
			"ratio": 82,
			"created": "2023-03-08T17:27:52.6783Z",
			"new": true,
			"ip": "17.250.98.153",
			"country": "N/A"
		},
		{
			"id": 218653,
			"deviceId": 160,
			"destinationPort": 443,
			"sourcePort": 48970,
			"proto": 6,
			"upload": 104,
			"download": 52,
			"total": 156,
			"ratio": 66,
			"created": "2023-03-07T09:46:29.6782Z",
			"new": true,
			"ip": "13.227.219.7",
			"country": "US",
			"reverse": {
				"name": "server-13-227-219-7.ams54.r.cloudfront.net"
			}
		}
]
```

The response from the same API, but with `Accept=application/csv`:
```csv
ID;DeviceID;DestinationPort;SourcePort;Proto;Upload;Download;Total;Ratio;Created;New;IP;Country;Reverse Name;Reverse Country;Reverse Organization
241265;167;443;54683;6;777;164;941;82;2023-03-08T17:27:52.6783Z;true;17.250.98.153;N/A;;;
218653;160;443;48970;6;104;52;156;66;2023-03-07T09:46:29.6782Z;true;13.227.219.7;US;server-13-227-219-7.ams54.r.cloudfront.net;;
```

You can notice a couple of empty columns because they were defined in the struct itself but never had any value in this case.
